### PR TITLE
[TASK] Prepare release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: publish
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    name: Ensure GitHub Release with extension TER artifact and publishing to TER
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    env:
+      TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify tag
+        run: |
+          if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
+            echo "ERR: Invalid publish version tag: ${{ github.ref }}"
+            exit 1
+          fi
+
+      - name: Get version
+        id: get-version
+        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: Get comment
+        id: get-comment
+        run: |
+          readonly local releaseCommentPrependBody="$( git tag -l ${{ env.version }} --format '%(contents)' )"
+          if (( $(grep -c . <<<"${releaseCommentPrependBody// }") > 1 )); then
+            {
+              echo 'releaseCommentPrependBody<<EOF'
+              echo "$releaseCommentPrependBody"
+              echo EOF
+            } >> "$GITHUB_ENV"
+          fi
+          {
+            echo 'terReleaseNotes<<EOF'
+            echo "https://github.com/${{ github.repository }}/releases/tag/${{ env.version }}"
+            echo EOF
+          } >> "$GITHUB_ENV"
+
+      # Note that when release already exists for tag, only files will be uploaded and lets this acting as a
+      # fallback to ensure that a real GitHub release is created for the tag along with extension artifacts.
+      - name: Create release and upload artifacts in the same step
+        uses: softprops/action-gh-release@v2
+        if: ${{startsWith(github.ref, 'refs/tags/') }}
+        with:
+          name: "[RELEASE] ${{ env.version }}"
+          body: "${{ env.releaseCommentPrependBody }}"
+          generate_release_notes: true
+          files: |
+            LICENSE
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -200,3 +200,24 @@ $this->setUpFrontendRootPage(
     false,
 );
 ```
+
+## Create a release (maintainer only)
+
+Prerequisites:
+
+* git binary
+* ssh key allowed to push new branches to the repository
+
+Checkout the release branch and 
+
+```shell
+TAG_BRANCH="main" \
+&& TAG_VERSION="1.2.3" \
+&& git fetch --all \
+&& git checkout ${TAG_BRANCH} \
+&& git pull --rebase \
+&& git tag "${TAG_VERSION}" \
+&& git push --tags
+```
+
+No need to create GitHub release manually - the publish workflow takes care of this.


### PR DESCRIPTION
This change adds the GitHub action workflow for
publish a release when tag(s) are pushed. That
includes creating a GitHub release for the tag.

`README.md` is modified to add release workflow
documentation for the maintainer(s).
