### PR TITLE
[TASK] Introduce scheduled `CI` execution (nightlies)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,27 @@
+name: cron
+
+on:
+  schedule:
+    - cron: '42 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    name: "dispatch nightly"
+    runs-on: ubuntu-22.04
+    permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        releaseBranch: [ "main", "1" ]
+    steps:
+      - name: "Checkout '${{ matrix.releaseBranch }}'"
+        uses: actions/checkout@v4
+        with:
+          ref: '${{ matrix.releaseBranch }}'
+
+      - name: "Execute 'ci.yml' on branch '${{ matrix.releaseBranch }}'"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run ci.yml --ref ${{ matrix.releaseBranch }}


### PR DESCRIPTION
GitHub actions provides the ability to create scheduled
actions, but takes only default branch into account and
makes it hard to realize scheduled (nightlies) for more
than one branch.

This change uses the GitHub cli tool as workaround to
dispatch action execution directly for a branch, which
includes only the `ci.yml` workflow.
