### PR TITLE
[TASK] Migrate to TYPO3 v14 (dev-main)

### DIFF
--- a/Tests/Unit/VersionCheckTest.php
+++ b/Tests/Unit/VersionCheckTest.php
@@ -23,7 +23,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 final class VersionCheckTest extends UnitTestCase
 {
-    private const SUPPORTED_TYPO3_MAJOR_VERSION = 13;
+    private const SUPPORTED_TYPO3_MAJOR_VERSION = 14;
 
     #[Test]
     public function ensureSupportedTypo3Version(): void

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require": {
         "php": "^8.2 || ^8.3 || ^8.4",
         "ext-json": "*",
-        "typo3/cms-core": "13.*.*@dev"
+        "typo3/cms-core": "14.*.*@dev"
     },
     "require-dev": {
         "bnf/phpstan-psr-container": "^1.1",
@@ -45,18 +45,18 @@
         "nikic/php-parser": "^5.4.0",
         "phpstan/phpstan": "^2.1.11",
         "phpunit/phpunit": "^11.2.5 || ^12.1.2",
-        "typo3/cms-backend": "13.*.*@dev",
-        "typo3/cms-belog": "13.*.*@dev",
-        "typo3/cms-beuser": "13.*.*@dev",
-        "typo3/cms-extbase": "13.*.*@dev",
-        "typo3/cms-fluid": "13.*.*@dev",
-        "typo3/cms-fluid-styled-content": "13.*.*@dev",
-        "typo3/cms-frontend": "13.*.*@dev",
-        "typo3/cms-install": "13.*.*@dev",
-        "typo3/cms-lowlevel": "13.*.*@dev",
-        "typo3/cms-setup": "13.*.*@dev",
-        "typo3/cms-tstemplate": "13.*.*@dev",
-        "typo3/minimal": "^13",
+        "typo3/cms-backend": "14.*.*@dev",
+        "typo3/cms-belog": "14.*.*@dev",
+        "typo3/cms-beuser": "14.*.*@dev",
+        "typo3/cms-extbase": "14.*.*@dev",
+        "typo3/cms-fluid": "14.*.*@dev",
+        "typo3/cms-fluid-styled-content": "14.*.*@dev",
+        "typo3/cms-frontend": "14.*.*@dev",
+        "typo3/cms-install": "14.*.*@dev",
+        "typo3/cms-lowlevel": "14.*.*@dev",
+        "typo3/cms-setup": "14.*.*@dev",
+        "typo3/cms-tstemplate": "14.*.*@dev",
+        "typo3/minimal": "dev-main@dev",
         "typo3/testing-framework": "^9.2.0"
     },
     "autoload": {


### PR DESCRIPTION
This change switches to TYPO3 v14 support, which includes
adopting changes of the `SiteBasedTestTrait` to the custom
implementation.

```shell
BIN_COMPOSER="$(which composer2-82)" \
&& ${BIN_COMPOSER} require --no-update \
  'typo3/cms-core':'14.*.*@dev' \
&& rm -rf .Build composer.lock \
&& ${BIN_COMPOSER} require --no-update --dev \
    'nikic/php-parser':'^5.4.0' \
    'typo3/cms-backend':'14.*.*@dev' \
    'typo3/cms-belog':'14.*.*@dev' \
    'typo3/cms-beuser':'14.*.*@dev' \
    'typo3/cms-extbase':'14.*.*@dev' \
    'typo3/cms-fluid':'14.*.*@dev' \
    'typo3/cms-fluid-styled-content':'14.*.*@dev' \
    'typo3/cms-frontend':'14.*.*@dev' \
    'typo3/cms-install':'14.*.*@dev' \
    'typo3/cms-lowlevel':'14.*.*@dev' \
    'typo3/cms-setup':'14.*.*@dev' \
    'typo3/cms-tstemplate':'14.*.*@dev' \
    'typo3/minimal':'dev-main@dev' \
&& ${BIN_COMPOSER} install
```
