### PR TITLE
[TASK] Update testing infrastructure

### DIFF
--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -17,7 +17,7 @@
 -->
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd"
     backupGlobals="true"
     beStrictAboutTestsThatDoNotTestAnything="false"
     bootstrap="FunctionalTestsBootstrap.php"

--- a/Build/phpunit/UnitTests.xml
+++ b/Build/phpunit/UnitTests.xml
@@ -17,7 +17,7 @@
 -->
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd"
     backupGlobals="true"
     beStrictAboutTestsThatDoNotTestAnything="false"
     bootstrap="UnitTestsBootstrap.php"

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "friendsofphp/php-cs-fixer": "^3.75.0",
         "nikic/php-parser": "^5.4.0",
         "phpstan/phpstan": "^2.1.11",
-        "phpunit/phpunit": "^10.5.45",
+        "phpunit/phpunit": "^11.2.5 || ^12.1.2",
         "typo3/cms-backend": "13.*.*@dev",
         "typo3/cms-belog": "13.*.*@dev",
         "typo3/cms-beuser": "13.*.*@dev",
@@ -54,7 +54,7 @@
         "typo3/cms-setup": "13.*.*@dev",
         "typo3/cms-tstemplate": "13.*.*@dev",
         "typo3/minimal": "^13",
-        "typo3/testing-framework": "^8.2.7"
+        "typo3/testing-framework": "^9.2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
With this change, the testing infrastructure is modernized
to newer `PHPUnit` and `typo3/testing-framework`.

```shell
BIN_COMPOSER="$(which composer2-82)" \
&& rm -rf .Build composer.lock \
&& ${BIN_COMPOSER} require --no-update --dev \
    'phpunit/phpunit':'^11.2.5 || ^12.1.2' \
    'typo3/testing-framework':'^9.2.0' \
&& ${BIN_COMPOSER} install
```
