### PR TITLE
[TASK] Streamline GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: "CI"
 
 on:
   pull_request:
+  push:
+    branch:
+      - "2"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,3 +39,4 @@ jobs:
           files: |
             LICENSE
           fail_on_unmatched_files: true
+          make_latest: false


### PR DESCRIPTION
With this change created GitHub release will no
longer add the last commit message or annotated
git tag content as prolog. This repository does
not need preparation commited for a release and
last commit message is not use-full at all.
