### PR TITLE
[TASK] Use correct `COMPOSER_ROOT_VERSION` in `Build/Scripts/runTests.sh`

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -373,7 +373,7 @@ fi
 
 handleDbmsOptions
 
-COMPOSER_ROOT_VERSION="2.0.0-dev"
+COMPOSER_ROOT_VERSION="1.0.0-dev"
 CONTAINER_INTERACTIVE="-it --init"
 HOST_UID=$(id -u)
 USERSET=""


### PR DESCRIPTION
This change aligns the `COMPOSER_ROOT_VERSION` variable
in the `Build/Scripts/runTests.sh` command dispatcher.
