### PR TITLE
[TASK] Change `SiteBasedTestTrait::buildSiteConfiguration()` signature

### DIFF
--- a/Classes/SiteHandling/SiteBasedTestTrait.php
+++ b/Classes/SiteHandling/SiteBasedTestTrait.php
@@ -107,18 +107,22 @@ trait SiteBasedTestTrait
     }
 
     /**
+     * @param non-empty-string $base
+     * @param non-empty-string $websiteTitle
      * @param array<non-empty-string, mixed> $additionalRootConfiguration
      * @return array<non-empty-string, mixed>
      */
     protected function buildSiteConfiguration(
         int $rootPageId,
-        string $base = '',
+        string $base = '/',
+        string $websiteTitle = 'Home',
         array $additionalRootConfiguration = [],
     ): array {
         return array_merge(
             [
                 'rootPageId' => $rootPageId,
                 'base' => $base,
+                'websiteTitle' => $websiteTitle,
             ],
             $additionalRootConfiguration,
         );

--- a/README.md
+++ b/README.md
@@ -124,12 +124,30 @@ level to the `SiteConfiguation` similar to [writeSiteConfiguration() argument ad
 $this->buildSiteConfiguration(
     rootPageId: 1,
     base: 'https://acme.com/',
+    websiteTitle: 'Home',
     additionalRootConfiguration: [
       'settings' => [
         'some_settings' => 123,
       ],    
     ],
 );
+```
+
+Method signature:
+
+```php
+/**
+ * @param non-empty-string $base
+ * @param non-empty-string $websiteTitle
+ * @param array<non-empty-string, mixed> $additionalRootConfiguration
+ * @return array<non-empty-string, mixed>
+ */
+protected function buildSiteConfiguration(
+    int $rootPageId,
+    string $base = '/',
+    string $websiteTitle = 'Home',
+    array $additionalRootConfiguration = [],
+): array {}
 ```
 
 ### `LANGUAGE_PRESETS` class property

--- a/Tests/Functional/SiteBasedTestTrait/SiteBasedTestTraitWithCustomFunctionalTestCaseTest.php
+++ b/Tests/Functional/SiteBasedTestTrait/SiteBasedTestTraitWithCustomFunctionalTestCaseTest.php
@@ -26,8 +26,8 @@ final class SiteBasedTestTraitWithCustomFunctionalTestCaseTest extends Functiona
     use SiteBasedTestTrait;
 
     protected const LANGUAGE_PRESETS = [
-        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8'],
-        'FR' => ['id' => 1, 'title' => 'French', 'locale' => 'fr_FR.UTF8'],
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'custom' => ['customLanguageKey' => 'EN123']],
+        'FR' => ['id' => 1, 'title' => 'French', 'locale' => 'fr_FR.UTF8', 'custom' => ['customLanguageKey' => 'FR123']],
     ];
 
     #[Test]
@@ -38,6 +38,7 @@ final class SiteBasedTestTraitWithCustomFunctionalTestCaseTest extends Functiona
             $this->buildSiteConfiguration(
                 rootPageId: 1,
                 base: 'https://acme.com/',
+                websiteTitle: 'ACME Start Page'
             ),
             [
                 $this->buildDefaultLanguageConfiguration(


### PR DESCRIPTION
This change change adds the `websiteTitle` argument to
`SiteBasedTestTrait::buildSiteConfiguration()` as easy
way to define this usually always required option.

Documentation in `README.md` is aligned in the same go.

```php
/**
 * @param array<non-empty-string, mixed> $additionalRootConfiguration
 * @return array<non-empty-string, mixed>
 */
protected function buildSiteConfiguration(
    int $rootPageId = 1,
    string $base = '/',
    string $websiteTitle = 'Home',
    array $additionalRootConfiguration = [],
): array {}
```
